### PR TITLE
Fixed Broken Link in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ See the folder [examples/getting_started](https://github.com/rentruewang/bocoel/
 
 ## ✍️ Develop with BoCoEL
 
-Usage examples are under the folder [`examples`](https://github.com/rentruewang/bocoel/tree/main/examples). API reference can be found [here](https://bocoel.rentruewang.com/references/overview/).
+Usage examples are under the folder [`examples`](https://github.com/rentruewang/bocoel/tree/main/examples). API reference can be found [here](https://bocoel.rentruewang.com/references/overview.html).
 
 
 ## 🥰 Contributing


### PR DESCRIPTION
Currently in the section- Develop with BoCoEL

> API reference can be found [here](https://bocoel.rentruewang.com/references/overview/).

Results in a broken link - 
![image](https://github.com/user-attachments/assets/4e71400e-eac7-4caf-9d69-20ea3f340b42)

Fixed the link and now redirects correctly - 

![image](https://github.com/user-attachments/assets/13012d56-7d23-43f3-a3ab-60d68745dd0c)
